### PR TITLE
feat: update for 0.4.0-alpha2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ rand = "0.8.5"
 reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
-todel = { version = "0.4.0-alpha1", git = "https://github.com/eludris/todel" }
+todel = { version = "0.4.0-alpha1", git = "https://github.com/eludris/eludris", branch = "feature/spheres" }
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "time"] }
 tokio-tungstenite = { version = "0.17.2", features = ["rustls-tls-webpki-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,9 @@ anyhow = "1.0.66"
 futures = "0.3.25"
 log = "0.4.17"
 rand = "0.8.5"
-reqwest = { version = "0.11.13", default-features = false, features = [
-	"json",
-	"rustls-tls",
-] }
+reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 todel = { version = "0.4.0-alpha2", git = "https://github.com/eludris/eludris" }
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "time"] }
-tokio-tungstenite = { version = "0.17.2", features = [
-	"rustls-tls-webpki-roots",
-] }
+tokio-tungstenite = { version = "0.17.2", features = ["rustls-tls-webpki-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,14 @@ anyhow = "1.0.66"
 futures = "0.3.25"
 log = "0.4.17"
 rand = "0.8.5"
-reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11.13", default-features = false, features = [
+	"json",
+	"rustls-tls",
+] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
-todel = { version = "0.4.0-alpha1", git = "https://github.com/eludris/eludris", branch = "feature/spheres" }
+todel = { version = "0.4.0-alpha2", git = "https://github.com/eludris/eludris", branch = "main" }
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "time"] }
-tokio-tungstenite = { version = "0.17.2", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.17.2", features = [
+	"rustls-tls-webpki-roots",
+] }

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -1,0 +1,731 @@
+use std::{
+    future::{Future, IntoFuture},
+    pin::Pin,
+};
+
+use anyhow::Result;
+use todel::models::{
+    Category, CategoryEdit, CustomEmbed, Emoji, EmojiEdit, Member, MemberEdit, Message,
+    MessageCreate, MessageDisguise, MessageEdit, Sphere, SphereChannel, SphereChannelCreate,
+    SphereChannelEdit, SphereChannelType, SphereCreate, SphereType, StatusType, User, UserEdit,
+    UserProfileEdit,
+};
+
+use crate::{
+    models::{HttpResponse, UserIdentifier},
+    HttpClient,
+};
+
+#[must_use]
+pub struct EditEmoji<'a> {
+    http: &'a HttpClient,
+    emoji_id: u64,
+    data: EmojiEdit,
+}
+
+impl<'a> EditEmoji<'a> {
+    pub(crate) fn new(http: &'a HttpClient, emoji_id: u64) -> Self {
+        Self {
+            http,
+            emoji_id,
+            data: EmojiEdit {
+                name: String::new(),
+            },
+        }
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.data.name = name.into();
+        self
+    }
+}
+
+impl<'a> IntoFuture for EditEmoji<'a> {
+    type Output = Result<Emoji>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self
+                .http
+                .request::<Emoji, (), EmojiEdit>(
+                    "PATCH",
+                    &format!("emojis/{}", self.emoji_id),
+                    None,
+                    Some(self.data),
+                )
+                .await?
+            {
+                HttpResponse::Success(emoji) => Ok(emoji),
+                HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not edit emoji: {:?}", err)),
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct EditMember<'a> {
+    http: &'a HttpClient,
+    guild_id: u64,
+    member_identifier: UserIdentifier,
+    data: MemberEdit,
+}
+
+impl<'a> EditMember<'a> {
+    pub(crate) fn new(
+        http: &'a HttpClient,
+        guild_id: u64,
+        member_identifier: UserIdentifier,
+    ) -> Self {
+        Self {
+            http,
+            guild_id,
+            member_identifier,
+            data: MemberEdit {
+                nickname: None,
+                sphere_avatar: None,
+                sphere_banner: None,
+                sphere_bio: None,
+                sphere_status: None,
+            },
+        }
+    }
+
+    pub fn nickname(mut self, nickname: Option<impl Into<String>>) -> Self {
+        self.data.nickname = Some(nickname.map(Into::into));
+        self
+    }
+
+    pub fn sphere_avatar(mut self, avatar: Option<u64>) -> Self {
+        self.data.sphere_avatar = Some(avatar);
+        self
+    }
+
+    pub fn sphere_banner(mut self, banner: Option<u64>) -> Self {
+        self.data.sphere_banner = Some(banner);
+        self
+    }
+
+    pub fn sphere_bio(mut self, bio: Option<impl Into<String>>) -> Self {
+        self.data.sphere_bio = Some(bio.map(Into::into));
+        self
+    }
+
+    pub fn sphere_status(mut self, status: Option<impl Into<String>>) -> Self {
+        self.data.sphere_status = Some(status.map(Into::into));
+        self
+    }
+}
+
+impl<'a> IntoFuture for EditMember<'a> {
+    type Output = Result<Member>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self
+                .http
+                .request::<Member, (), MemberEdit>(
+                    "PATCH",
+                    &format!(
+                        "guilds/{}/members/{}",
+                        self.guild_id, self.member_identifier
+                    ),
+                    None,
+                    Some(self.data),
+                )
+                .await?
+            {
+                HttpResponse::Success(member) => Ok(member),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not edit member: {:?}", err))
+                }
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct CreateMessage<'a> {
+    http: &'a HttpClient,
+    channel_id: u64,
+    data: MessageCreate,
+}
+
+impl<'a> CreateMessage<'a> {
+    pub(crate) fn new(http: &'a HttpClient, channel_id: u64) -> Self {
+        Self {
+            http,
+            channel_id,
+            data: MessageCreate {
+                content: None,
+                attachments: vec![],
+                embeds: vec![],
+                disguise: None,
+                reference: None,
+            },
+        }
+    }
+
+    pub fn attachments(mut self, attachments: Vec<u64>) -> Self {
+        self.data.attachments = attachments;
+        self
+    }
+
+    pub fn content(mut self, content: impl Into<String>) -> Self {
+        self.data.content = Some(content.into());
+        self
+    }
+
+    pub fn disguise(mut self, disguise: Option<MessageDisguise>) -> Self {
+        self.data.disguise = disguise;
+        self
+    }
+
+    pub fn embeds(mut self, embeds: Vec<CustomEmbed>) -> Self {
+        self.data.embeds = embeds;
+        self
+    }
+
+    pub fn reference(mut self, reference: Option<u64>) -> Self {
+        self.data.reference = reference;
+        self
+    }
+}
+
+impl<'a> IntoFuture for CreateMessage<'a> {
+    type Output = Result<Message>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self
+                .http
+                .request::<Message, (), MessageCreate>(
+                    "POST",
+                    &format!("channels/{}/messages", self.channel_id),
+                    None,
+                    Some(self.data),
+                )
+                .await?
+            {
+                HttpResponse::Success(data) => Ok(data),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not send message: {:?}", err))
+                }
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct EditMessage<'a> {
+    http: &'a HttpClient,
+    channel_id: u64,
+    message_id: u64,
+    data: MessageEdit,
+}
+
+impl<'a> EditMessage<'a> {
+    pub(crate) fn new(http: &'a HttpClient, channel_id: u64, message_id: u64) -> Self {
+        Self {
+            http,
+            channel_id,
+            message_id,
+            data: MessageEdit {
+                content: None,
+                attachments: None,
+                embeds: None,
+            },
+        }
+    }
+
+    pub fn attachments(mut self, attachments: Vec<u64>) -> Self {
+        self.data.attachments = Some(attachments);
+        self
+    }
+
+    pub fn content(mut self, content: Option<impl Into<String>>) -> Self {
+        self.data.content = Some(content.map(Into::into));
+        self
+    }
+
+    pub fn embeds(mut self, embeds: Vec<CustomEmbed>) -> Self {
+        self.data.embeds = Some(embeds);
+        self
+    }
+}
+
+impl<'a> IntoFuture for EditMessage<'a> {
+    type Output = Result<Message>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self
+                .http
+                .request::<Message, (), MessageEdit>(
+                    "PATCH",
+                    &format!("channels/{}/messages/{}", self.channel_id, self.message_id),
+                    None,
+                    Some(self.data),
+                )
+                .await?
+            {
+                HttpResponse::Success(message) => Ok(message),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not edit message: {:?}", err))
+                }
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct GetMessages<'a> {
+    http: &'a HttpClient,
+    channel_id: u64,
+    limit: Option<u32>,
+    before: Option<u64>,
+    after: Option<u64>,
+}
+
+impl<'a> GetMessages<'a> {
+    pub(crate) fn new(http: &'a HttpClient, channel_id: u64) -> Self {
+        Self {
+            http,
+            channel_id,
+            limit: None,
+            before: None,
+            after: None,
+        }
+    }
+
+    pub fn after(mut self, after: u64) -> Self {
+        self.after = Some(after);
+        self
+    }
+
+    pub fn before(mut self, before: u64) -> Self {
+        self.before = Some(before);
+        self
+    }
+
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+impl<'a> IntoFuture for GetMessages<'a> {
+    type Output = Result<Vec<Message>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let mut query = vec![];
+            if let Some(before) = self.before {
+                query.push(("before", before.to_string()));
+            }
+            if let Some(after) = self.after {
+                query.push(("after", after.to_string()));
+            }
+            if let Some(limit) = self.limit {
+                query.push(("limit", limit.to_string()));
+            }
+            match self
+                .http
+                .request::<Vec<Message>, Vec<(&str, String)>, ()>(
+                    "GET",
+                    &format!("channels/{}/messages", self.channel_id),
+                    Some(&query),
+                    None,
+                )
+                .await?
+            {
+                HttpResponse::Success(messages) => Ok(messages),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not get messages: {:?}", err))
+                }
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct EditCategory<'a> {
+    http: &'a HttpClient,
+    sphere_id: u64,
+    category_id: u64,
+    data: CategoryEdit,
+}
+
+impl<'a> EditCategory<'a> {
+    pub(crate) fn new(http: &'a HttpClient, sphere_id: u64, category_id: u64) -> Self {
+        Self {
+            http,
+            sphere_id,
+            category_id,
+            data: CategoryEdit {
+                name: None,
+                position: None,
+            },
+        }
+    }
+}
+
+impl<'a> EditCategory<'a> {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.data.name = Some(name.into());
+        self
+    }
+
+    pub fn position(mut self, position: u32) -> Self {
+        self.data.position = Some(position);
+        self
+    }
+}
+
+impl<'a> IntoFuture for EditCategory<'a> {
+    type Output = Result<Category>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self
+                .http
+                .request::<Category, (), CategoryEdit>(
+                    "PATCH",
+                    &format!("spheres/{}/categories/{}", self.sphere_id, self.category_id),
+                    None,
+                    Some(self.data),
+                )
+                .await?
+            {
+                HttpResponse::Success(category) => Ok(category),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not edit category: {:?}", err))
+                }
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct CreateChannel<'a> {
+    http: &'a HttpClient,
+    sphere_id: u64,
+    data: SphereChannelCreate,
+}
+
+impl<'a> CreateChannel<'a> {
+    pub(crate) fn new(
+        http: &'a HttpClient,
+        sphere_id: u64,
+        name: String,
+        channel_type: SphereChannelType,
+    ) -> Self {
+        Self {
+            http,
+            sphere_id,
+            data: SphereChannelCreate {
+                name: name,
+                channel_type: channel_type,
+                topic: None,
+                category_id: None,
+            },
+        }
+    }
+
+    pub fn category_id(mut self, category_id: u64) -> Self {
+        self.data.category_id = Some(category_id);
+        self
+    }
+
+    pub fn topic(mut self, topic: impl Into<String>) -> Self {
+        self.data.topic = Some(topic.into());
+        self
+    }
+}
+
+impl<'a> IntoFuture for CreateChannel<'a> {
+    type Output = Result<SphereChannel>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self
+                .http
+                .request::<SphereChannel, (), SphereChannelCreate>(
+                    "POST",
+                    &format!("spheres/{}/channels", self.sphere_id),
+                    None,
+                    Some(self.data),
+                )
+                .await?
+            {
+                HttpResponse::Success(channel) => Ok(channel),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not create channel: {:?}", err))
+                }
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct EditChannel<'a> {
+    http: &'a HttpClient,
+    sphere_id: u64,
+    channel_id: u64,
+    data: SphereChannelEdit,
+}
+
+impl<'a> EditChannel<'a> {
+    pub(crate) fn new(http: &'a HttpClient, sphere_id: u64, channel_id: u64) -> Self {
+        Self {
+            http,
+            sphere_id,
+            channel_id,
+            data: SphereChannelEdit {
+                name: None,
+                topic: None,
+                position: None,
+                category_id: None,
+            },
+        }
+    }
+
+    pub fn category_id(mut self, category_id: u64) -> Self {
+        self.data.category_id = Some(category_id);
+        self
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.data.name = Some(name.into());
+        self
+    }
+
+    pub fn position(mut self, position: u32) -> Self {
+        self.data.position = Some(position);
+        self
+    }
+
+    pub fn topic(mut self, topic: Option<impl Into<String>>) -> Self {
+        self.data.topic = Some(topic.map(Into::into));
+        self
+    }
+}
+
+impl<'a> IntoFuture for EditChannel<'a> {
+    type Output = Result<SphereChannel>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self
+                .http
+                .request::<SphereChannel, (), SphereChannelEdit>(
+                    "PATCH",
+                    &format!("spheres/{}/channels/{}", self.sphere_id, self.channel_id),
+                    None,
+                    Some(self.data),
+                )
+                .await?
+            {
+                HttpResponse::Success(channel) => Ok(channel),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not edit channel: {:?}", err))
+                }
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct CreateSphere<'a> {
+    http: &'a HttpClient,
+    data: SphereCreate,
+}
+
+impl<'a> CreateSphere<'a> {
+    pub(crate) fn new(http: &'a HttpClient, slug: String, sphere_type: SphereType) -> Self {
+        Self {
+            http,
+            data: SphereCreate {
+                slug,
+                sphere_type,
+                name: None,
+                description: None,
+                icon: None,
+                banner: None,
+            },
+        }
+    }
+
+    pub fn banner(mut self, banner: u64) -> Self {
+        self.data.banner = Some(banner);
+        self
+    }
+
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.data.description = Some(description.into());
+        self
+    }
+
+    pub fn icon(mut self, icon: u64) -> Self {
+        self.data.icon = Some(icon);
+        self
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.data.name = Some(name.into());
+        self
+    }
+}
+
+impl<'a> IntoFuture for CreateSphere<'a> {
+    type Output = Result<Sphere>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self
+                .http
+                .request::<Sphere, (), SphereCreate>("POST", "spheres", None, Some(self.data))
+                .await?
+            {
+                HttpResponse::Success(sphere) => Ok(sphere),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not create sphere: {:?}", err))
+                }
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct EditUser<'a> {
+    http: &'a HttpClient,
+    data: UserEdit,
+}
+
+impl<'a> EditUser<'a> {
+    pub(crate) fn new(http: &'a HttpClient, password: String) -> Self {
+        Self {
+            http,
+            data: UserEdit {
+                password: password,
+                username: None,
+                email: None,
+                new_password: None,
+            },
+        }
+    }
+
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.data.email = Some(email.into());
+        self
+    }
+
+    pub fn new_password(mut self, new_password: impl Into<String>) -> Self {
+        self.data.new_password = Some(new_password.into());
+        self
+    }
+
+    pub fn username(mut self, username: impl Into<String>) -> Self {
+        self.data.username = Some(username.into());
+        self
+    }
+}
+
+impl<'a> IntoFuture for EditUser<'a> {
+    type Output = Result<User>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self
+                .http
+                .request::<User, (), UserEdit>("PATCH", "users", None, Some(self.data))
+                .await?
+            {
+                HttpResponse::Success(user) => Ok(user),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not update user: {:?}", err))
+                }
+            }
+        })
+    }
+}
+
+#[must_use]
+pub struct EditUserProfile<'a> {
+    http: &'a HttpClient,
+    data: UserProfileEdit,
+}
+
+impl<'a> EditUserProfile<'a> {
+    pub(crate) fn new(http: &'a HttpClient) -> Self {
+        Self {
+            http,
+            data: UserProfileEdit {
+                avatar: None,
+                banner: None,
+                bio: None,
+                display_name: None,
+                status: None,
+                status_type: None,
+            },
+        }
+    }
+
+    pub fn avatar(mut self, avatar: Option<u64>) -> Self {
+        self.data.avatar = Some(avatar);
+        self
+    }
+
+    pub fn banner(mut self, banner: Option<u64>) -> Self {
+        self.data.banner = Some(banner);
+        self
+    }
+
+    pub fn bio(mut self, bio: Option<impl Into<String>>) -> Self {
+        self.data.bio = Some(bio.map(Into::into));
+        self
+    }
+
+    pub fn display_name(mut self, display_name: Option<impl Into<String>>) -> Self {
+        self.data.display_name = Some(display_name.map(Into::into));
+        self
+    }
+
+    pub fn status(mut self, status: Option<impl Into<String>>) -> Self {
+        self.data.status = Some(status.map(Into::into));
+        self
+    }
+
+    pub fn status_type(mut self, status_type: StatusType) -> Self {
+        self.data.status_type = Some(status_type);
+        self
+    }
+}
+
+impl<'a> IntoFuture for EditUserProfile<'a> {
+    type Output = Result<User>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            match self.http
+                .request::<User, (), UserProfileEdit>("PATCH", "users/profile", None, Some(self.data))
+                .await?
+            {
+                HttpResponse::Success(user) => Ok(user),
+                HttpResponse::Error(err) => {
+                    Err(anyhow::anyhow!("Could not update user profile: {:?}", err))
+                }
+            }
+        })
+    }
+}

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -177,8 +177,8 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    pub fn disguise(mut self, disguise: Option<MessageDisguise>) -> Self {
-        self.data.disguise = disguise;
+    pub fn disguise(mut self, disguise: MessageDisguise) -> Self {
+        self.data.disguise = Some(disguise);
         self
     }
 
@@ -187,8 +187,8 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    pub fn reference(mut self, reference: Option<u64>) -> Self {
-        self.data.reference = reference;
+    pub fn reference(mut self, reference: u64) -> Self {
+        self.data.reference = Some(reference);
         self
     }
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -10,13 +10,16 @@ use std::{
 use anyhow::{bail, Result};
 use futures::{stream::SplitStream, SinkExt, Stream, StreamExt};
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use todel::models::{ClientPayload, ServerPayload, Sphere, User};
+use todel::models::{ClientPayload, ServerPayload, User};
 use tokio::{net::TcpStream, sync::Mutex, task::JoinHandle, time};
 use tokio_tungstenite::{
     connect_async, tungstenite::Message as WSMessage, MaybeTlsStream, WebSocketStream,
 };
 
-use crate::{models::Event, GATEWAY_URL};
+use crate::{
+    models::{CachedMember, CachedSphere, Event},
+    GATEWAY_URL,
+};
 
 type WsReceiver = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
@@ -25,7 +28,7 @@ type WsReceiver = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 pub struct GatewayData {
     user: Option<User>,
     users: HashMap<u64, User>,
-    spheres: HashMap<u64, Sphere>,
+    spheres: HashMap<u64, CachedSphere>,
 }
 
 /// A Stream of Pandemonium events
@@ -257,10 +260,11 @@ impl Stream for Events {
                                     ServerPayload::Authenticated { user, spheres } => {
                                         data.user = Some(user);
                                         spheres.into_iter().for_each(|sphere| {
-                                            data.spheres.insert(sphere.id, sphere);
+                                            let cached_sphere: CachedSphere = sphere.clone().into();
                                             for member in sphere.members {
                                                 data.users.insert(member.user.id, member.user);
                                             }
+                                            data.spheres.insert(cached_sphere.id, cached_sphere);
                                         });
                                         break Poll::Ready(Some(Event::Authenticated));
                                     }
@@ -281,11 +285,27 @@ impl Stream for Events {
                                         }));
                                     }
                                     ServerPayload::SphereJoin(sphere) => {
-                                        data.spheres.insert(sphere.id, sphere.clone());
-                                        break Poll::Ready(Some(Event::SphereJoin(sphere)));
+                                        let cached_sphere: CachedSphere = sphere.into();
+                                        data.spheres
+                                            .insert(cached_sphere.id, cached_sphere.clone());
+                                        break Poll::Ready(Some(Event::SphereJoin(cached_sphere)));
                                     }
                                     ServerPayload::SphereMemberJoin { user, sphere_id } => {
                                         data.users.insert(user.id, user.clone());
+                                        if let Some(sphere) = data.spheres.get_mut(&sphere_id) {
+                                            let member = CachedMember {
+                                                user_id: user.id,
+                                                sphere_id,
+                                                nickname: None,
+                                                sphere_avatar: None,
+                                                sphere_banner: None,
+                                                sphere_bio: None,
+                                                sphere_status: None,
+                                            };
+                                            sphere.members.push(member);
+                                        } else {
+                                            log::warn!("Sphere {} not found in cache", sphere_id);
+                                        }
                                         break Poll::Ready(Some(Event::SphereMemberJoin {
                                             user,
                                             sphere_id,
@@ -346,6 +366,7 @@ impl Stream for Events {
                                             sphere_id,
                                         }));
                                     }
+                                    _ => todo!(),
                                 }
                             }
                         }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -271,6 +271,37 @@ impl Stream for Events {
                                     ServerPayload::MessageCreate(msg) => {
                                         break Poll::Ready(Some(Event::Message(msg)));
                                     }
+                                    ServerPayload::MessageUpdate {
+                                        channel_id,
+                                        message_id,
+                                        data,
+                                    } => {
+                                        break Poll::Ready(Some(Event::MessageUpdate {
+                                            channel_id,
+                                            message_id,
+                                            data,
+                                        }));
+                                    }
+                                    ServerPayload::MessageEmbedPopulate {
+                                        channel_id,
+                                        message_id,
+                                        embeds,
+                                    } => {
+                                        break Poll::Ready(Some(Event::MessageEmbedPopulate {
+                                            channel_id,
+                                            message_id,
+                                            embeds,
+                                        }));
+                                    }
+                                    ServerPayload::MessageDelete {
+                                        channel_id,
+                                        message_id,
+                                    } => {
+                                        break Poll::Ready(Some(Event::MessageDelete {
+                                            channel_id,
+                                            message_id,
+                                        }));
+                                    }
                                     ServerPayload::UserUpdate(user) => {
                                         data.users.insert(user.id, user.clone());
                                         break Poll::Ready(Some(Event::UserUpdate(user)));
@@ -290,6 +321,45 @@ impl Stream for Events {
                                             .insert(cached_sphere.id, cached_sphere.clone());
                                         break Poll::Ready(Some(Event::SphereJoin(cached_sphere)));
                                     }
+                                    ServerPayload::SphereUpdate {
+                                        data: sphere_data,
+                                        sphere_id,
+                                    } => {
+                                        if let Some(sphere) = data.spheres.get_mut(&sphere_id) {
+                                            let old = sphere.clone();
+                                            let data = sphere_data.clone();
+                                            if let Some(name) = sphere_data.name {
+                                                sphere.name = name;
+                                            }
+                                            if let Some(description) = sphere_data.description {
+                                                sphere.description = description;
+                                            }
+                                            if let Some(sphere_type) = sphere_data.sphere_type {
+                                                sphere.sphere_type = sphere_type;
+                                            }
+                                            if let Some(icon) = sphere_data.icon {
+                                                sphere.icon = icon;
+                                            }
+                                            if let Some(banner) = sphere_data.banner {
+                                                sphere.banner = banner;
+                                            }
+
+                                            break Poll::Ready(Some(Event::SphereUpdate {
+                                                old,
+                                                data,
+                                                sphere_id,
+                                            }));
+                                        } else {
+                                            log::warn!("Sphere {} not found in cache", sphere_id);
+                                        }
+                                    }
+                                    ServerPayload::SphereLeave { sphere_id } => {
+                                        if let Some(sphere) = data.spheres.remove(&sphere_id) {
+                                            break Poll::Ready(Some(Event::SphereLeave(sphere)));
+                                        } else {
+                                            log::warn!("Sphere {} not found in cache", sphere_id);
+                                        }
+                                    }
                                     ServerPayload::SphereMemberJoin { user, sphere_id } => {
                                         data.users.insert(user.id, user.clone());
                                         if let Some(sphere) = data.spheres.get_mut(&sphere_id) {
@@ -302,14 +372,76 @@ impl Stream for Events {
                                                 sphere_bio: None,
                                                 sphere_status: None,
                                             };
-                                            sphere.members.push(member);
+                                            sphere.members.insert(user.id, member.clone());
+                                            break Poll::Ready(Some(Event::SphereMemberJoin(
+                                                member,
+                                            )));
                                         } else {
                                             log::warn!("Sphere {} not found in cache", sphere_id);
                                         }
-                                        break Poll::Ready(Some(Event::SphereMemberJoin {
-                                            user,
+                                    }
+                                    ServerPayload::MemberUpdate {
+                                        data: member_data,
+                                        user_id,
+                                        sphere_id,
+                                    } => {
+                                        // Clone the user before mutable borrow
+                                        let Some(old_user) = data.users.get(&user_id).cloned() else {
+                                            log::warn!("User {} not found in cache", user_id);
+                                            continue;
+                                        };
+
+                                        let Some(sphere) = data.spheres.get_mut(&sphere_id) else {
+                                            log::warn!("Sphere {} not found in cache", sphere_id);
+                                            continue;
+                                        };
+
+                                        let Some(member) = sphere.members.get_mut(&user_id) else {
+                                            log::warn!(
+                                                "Member {} not found in sphere {}",
+                                                user_id,
+                                                sphere_id
+                                            );
+                                            continue;
+                                        };
+
+                                        let old = member.clone();
+                                        let old_member = old.into_member(old_user);
+                                        let data = member_data.clone();
+                                        if let Some(nickname) = member_data.nickname {
+                                            member.nickname = nickname;
+                                        }
+                                        if let Some(avatar) = member_data.sphere_avatar {
+                                            member.sphere_avatar = avatar;
+                                        }
+                                        if let Some(banner) = member_data.sphere_banner {
+                                            member.sphere_banner = banner;
+                                        }
+                                        if let Some(bio) = member_data.sphere_bio {
+                                            member.sphere_bio = bio;
+                                        }
+                                        if let Some(status) = member_data.sphere_status {
+                                            member.sphere_status = status;
+                                        }
+                                        break Poll::Ready(Some(Event::MemberUpdate {
+                                            old: old_member,
+                                            data,
+                                            user_id,
                                             sphere_id,
                                         }));
+                                    }
+                                    ServerPayload::SphereMemberLeave { user_id, sphere_id } => {
+                                        if let Some(member) = data
+                                            .spheres
+                                            .get_mut(&sphere_id)
+                                            .and_then(|s| s.members.remove(&user_id))
+                                        {
+                                            break Poll::Ready(Some(Event::SphereMemberLeave(
+                                                member,
+                                            )));
+                                        } else {
+                                            log::warn!("Sphere {} not found in cache", sphere_id);
+                                        }
                                     }
                                     ServerPayload::CategoryCreate {
                                         category,
@@ -366,7 +498,97 @@ impl Stream for Events {
                                             sphere_id,
                                         }));
                                     }
-                                    _ => todo!(),
+                                    ServerPayload::EmojiCreate { sphere_id, emoji } => {
+                                        if let Some(sphere) = data.spheres.get_mut(&sphere_id) {
+                                            sphere.emojis.insert(emoji.id, emoji.clone());
+                                            break Poll::Ready(Some(Event::EmojiCreate(emoji)));
+                                        } else {
+                                            log::warn!("Sphere {} not found in cache", sphere_id);
+                                        }
+                                    }
+                                    ServerPayload::EmojiUpdate {
+                                        sphere_id,
+                                        emoji_id,
+                                        data: emoji_data,
+                                    } => {
+                                        let Some(sphere) = data.spheres.get_mut(&sphere_id) else {
+                                            log::warn!("Sphere {} not found in cache", sphere_id);
+                                            continue;
+                                        };
+
+                                        let Some(emoji) = sphere.emojis.get_mut(&emoji_id) else {
+                                            log::warn!(
+                                                "Emoji {} not found in sphere {}",
+                                                emoji_id,
+                                                sphere_id
+                                            );
+                                            continue;
+                                        };
+
+                                        let old = emoji.clone();
+                                        let data = emoji_data.clone();
+                                        emoji.name = emoji_data.name;
+                                        break Poll::Ready(Some(Event::EmojiUpdate {
+                                            old,
+                                            data,
+                                            sphere_id,
+                                            emoji_id,
+                                        }));
+                                    }
+                                    ServerPayload::EmojiDelete {
+                                        sphere_id,
+                                        emoji_id,
+                                    } => {
+                                        let Some(sphere) = data.spheres.get_mut(&sphere_id) else {
+                                            log::warn!("Sphere {} not found in cache", sphere_id);
+                                            continue;
+                                        };
+
+                                        if let Some(emoji) = sphere.emojis.remove(&emoji_id) {
+                                            break Poll::Ready(Some(Event::EmojiDelete(emoji)));
+                                        } else {
+                                            log::warn!(
+                                                "Emoji {} not found in sphere {}",
+                                                emoji_id,
+                                                sphere_id
+                                            );
+                                        }
+                                    }
+                                    ServerPayload::MessageReact {
+                                        channel_id,
+                                        message_id,
+                                        user_id,
+                                        emoji,
+                                    } => {
+                                        break Poll::Ready(Some(Event::MessageReact {
+                                            channel_id,
+                                            message_id,
+                                            user_id,
+                                            emoji,
+                                        }));
+                                    }
+                                    ServerPayload::MessageReactionClear {
+                                        channel_id,
+                                        message_id,
+                                    } => {
+                                        break Poll::Ready(Some(Event::MessageReactionClear {
+                                            channel_id,
+                                            message_id,
+                                        }));
+                                    }
+                                    ServerPayload::MessageReactionDelete {
+                                        channel_id,
+                                        message_id,
+                                        user_id,
+                                        emoji,
+                                    } => {
+                                        break Poll::Ready(Some(Event::MessageReactionDelete {
+                                            channel_id,
+                                            message_id,
+                                            user_id,
+                                            emoji,
+                                        }));
+                                    }
                                 }
                             }
                         }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -290,12 +290,12 @@ impl Stream for Events {
                                             sphere_id,
                                         }));
                                     }
-                                    ServerPayload::CategoryEdit {
+                                    ServerPayload::CategoryUpdate {
                                         data,
                                         category_id,
                                         sphere_id,
                                     } => {
-                                        break Poll::Ready(Some(Event::CategoryEdit {
+                                        break Poll::Ready(Some(Event::CategoryUpdate {
                                             data,
                                             category_id,
                                             sphere_id,
@@ -316,12 +316,12 @@ impl Stream for Events {
                                             sphere_id,
                                         }));
                                     }
-                                    ServerPayload::SphereChannelEdit {
+                                    ServerPayload::SphereChannelUpdate {
                                         data,
                                         channel_id,
                                         sphere_id,
                                     } => {
-                                        break Poll::Ready(Some(Event::SphereChannelEdit {
+                                        break Poll::Ready(Some(Event::SphereChannelUpdate {
                                             data,
                                             channel_id,
                                             sphere_id,

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -386,7 +386,8 @@ impl Stream for Events {
                                         sphere_id,
                                     } => {
                                         // Clone the user before mutable borrow
-                                        let Some(old_user) = data.users.get(&user_id).cloned() else {
+                                        let Some(old_user) = data.users.get(&user_id).cloned()
+                                        else {
                                             log::warn!("User {} not found in cache", user_id);
                                             continue;
                                         };

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -24,6 +24,7 @@ type WsReceiver = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 #[derive(Default, Debug, Clone)]
 pub struct GatewayData {
     user: Option<User>,
+    users: HashMap<u64, User>,
     spheres: HashMap<u64, Sphere>,
 }
 
@@ -255,8 +256,11 @@ impl Stream for Events {
                                     | ServerPayload::Hello { .. } => {}
                                     ServerPayload::Authenticated { user, spheres } => {
                                         data.user = Some(user);
-                                        spheres.into_iter().for_each(|s| {
-                                            data.spheres.insert(s.id, s);
+                                        spheres.into_iter().for_each(|sphere| {
+                                            data.spheres.insert(sphere.id, sphere);
+                                            for member in sphere.members {
+                                                data.users.insert(member.user.id, member.user);
+                                            }
                                         });
                                         break Poll::Ready(Some(Event::Authenticated));
                                     }
@@ -264,18 +268,24 @@ impl Stream for Events {
                                         break Poll::Ready(Some(Event::Message(msg)));
                                     }
                                     ServerPayload::UserUpdate(user) => {
+                                        data.users.insert(user.id, user.clone());
                                         break Poll::Ready(Some(Event::UserUpdate(user)));
                                     }
                                     ServerPayload::PresenceUpdate { status, user_id } => {
+                                        if let Some(user) = data.users.get_mut(&user_id) {
+                                            user.status = status.clone();
+                                        }
                                         break Poll::Ready(Some(Event::PresenceUpdate {
                                             user_id,
                                             status,
                                         }));
                                     }
                                     ServerPayload::SphereJoin(sphere) => {
+                                        data.spheres.insert(sphere.id, sphere.clone());
                                         break Poll::Ready(Some(Event::SphereJoin(sphere)));
                                     }
                                     ServerPayload::SphereMemberJoin { user, sphere_id } => {
+                                        data.users.insert(user.id, user.clone());
                                         break Poll::Ready(Some(Event::SphereMemberJoin {
                                             user,
                                             sphere_id,

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,9 +1,9 @@
 use crate::{models::HttpResponse, GatewayClient, REST_URL};
 use anyhow::Result;
-use reqwest::Client;
+use reqwest::{Client, Method};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
-use std::{fmt::Display, time::Duration};
+use serde_json::json;
+use std::{fmt::Display, str::FromStr, time::Duration};
 use todel::{
     ErrorResponse, InstanceInfo, Message, MessageCreate, MessageDisguise,
     PasswordDeleteCredentials, ResetPassword, Session, SessionCreate, SessionCreated, UpdateUser,
@@ -70,7 +70,10 @@ impl HttpClient {
         loop {
             match self
                 .client
-                .post(format!("{}/{}", self.rest_url, path))
+                .request(
+                    Method::from_str(method)?,
+                    format!("{}/{}", self.rest_url, path),
+                )
                 .header("Authorization", &self.token)
                 .json(&body)
                 .send()

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,7 +4,7 @@ use reqwest::{Client, Method};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{fmt::Display, str::FromStr, time::Duration};
-use todel::{
+use todel::models::{
     ErrorResponse, InstanceInfo, Message, MessageCreate, MessageDisguise,
     PasswordDeleteCredentials, ResetPassword, Session, SessionCreate, SessionCreated, UpdateUser,
     UpdateUserProfile, User, UserCreate,
@@ -116,6 +116,7 @@ impl HttpClient {
         let message = MessageCreate {
             content: content.to_string(),
             disguise: None,
+            reference: None, // TODO: Add references
         };
         match self
             .request::<Message, MessageCreate>("POST", "messages", Some(message))
@@ -135,6 +136,7 @@ impl HttpClient {
         let message = MessageCreate {
             content: content.to_string(),
             disguise: Some(disguise),
+            reference: None,
         };
         match self
             .request::<Message, MessageCreate>("POST", "messages", Some(message))

--- a/src/http.rs
+++ b/src/http.rs
@@ -124,25 +124,29 @@ impl HttpClient {
     /// Send a message
     pub async fn send_message<C: Display>(
         &self,
+        channel_id: u64,
         content: C,
         reference: Option<u64>,
     ) -> Result<Message> {
-        self.send_msg(content.to_string(), None, reference).await
+        self.send_msg(channel_id, content.to_string(), None, reference)
+            .await
     }
 
     /// Send a message with a [`MessageDisguise`]
     pub async fn send_message_with_disguise<C: Display>(
         &self,
+        channel_id: u64,
         content: C,
         disguise: MessageDisguise,
         reference: Option<u64>,
     ) -> Result<Message> {
-        self.send_msg(content.to_string(), Some(disguise), reference)
+        self.send_msg(channel_id, content.to_string(), Some(disguise), reference)
             .await
     }
 
     async fn send_msg(
         &self,
+        channel_id: u64,
         content: String,
         disguise: Option<MessageDisguise>,
         reference: Option<u64>,
@@ -153,11 +157,16 @@ impl HttpClient {
             reference,
         };
         match self
-            .request::<Message, (), MessageCreate>("POST", "messages", None, Some(message))
+            .request::<Message, (), MessageCreate>(
+                "POST",
+                &format!("/channels/{}/messages", channel_id),
+                None,
+                Some(message),
+            )
             .await?
         {
             HttpResponse::Success(data) => Ok(data),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not send message: {:?}", err)),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could) not send message: {:?}", err)),
         }
     }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -112,31 +112,35 @@ impl HttpClient {
     }
 
     /// Send a message
-    pub async fn send_message<C: Display>(&self, content: C) -> Result<Message> {
-        let message = MessageCreate {
-            content: content.to_string(),
-            disguise: None,
-            reference: None, // TODO: Add references
-        };
-        match self
-            .request::<Message, MessageCreate>("POST", "messages", Some(message))
-            .await?
-        {
-            HttpResponse::Success(data) => Ok(data),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not send message: {:?}", err)),
-        }
+    pub async fn send_message<C: Display>(
+        &self,
+        content: C,
+        reference: Option<u64>,
+    ) -> Result<Message> {
+        self.send_msg(content.to_string(), None, reference).await
     }
 
-    /// Send a message with a disguise
+    /// Send a message with a [`MessageDisguise`]
     pub async fn send_message_with_disguise<C: Display>(
         &self,
         content: C,
         disguise: MessageDisguise,
+        reference: Option<u64>,
+    ) -> Result<Message> {
+        self.send_msg(content.to_string(), Some(disguise), reference)
+            .await
+    }
+
+    async fn send_msg(
+        &self,
+        content: String,
+        disguise: Option<MessageDisguise>,
+        reference: Option<u64>,
     ) -> Result<Message> {
         let message = MessageCreate {
-            content: content.to_string(),
-            disguise: Some(disguise),
-            reference: None,
+            content,
+            disguise,
+            reference,
         };
         match self
             .request::<Message, MessageCreate>("POST", "messages", Some(message))

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,11 +2,12 @@ use crate::{models::HttpResponse, GatewayClient, REST_URL};
 use anyhow::Result;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::{fmt::Display, time::Duration};
 use todel::{
     ErrorResponse, InstanceInfo, Message, MessageCreate, MessageDisguise,
-    PasswordDeleteCredentials, Session, SessionCreate, SessionCreated,
+    PasswordDeleteCredentials, ResetPassword, Session, SessionCreate, SessionCreated, UpdateUser,
+    UpdateUserProfile, User, UserCreate,
 };
 use tokio::time;
 
@@ -62,6 +63,7 @@ impl HttpClient {
 
     async fn request<T: for<'a> Deserialize<'a>, B: Serialize + Sized>(
         &self,
+        method: &str,
         path: &str,
         body: Option<B>,
     ) -> Result<HttpResponse<T>> {
@@ -113,7 +115,7 @@ impl HttpClient {
             disguise: None,
         };
         match self
-            .request::<Message, MessageCreate>("messages", Some(message))
+            .request::<Message, MessageCreate>("POST", "messages", Some(message))
             .await?
         {
             HttpResponse::Success(data) => Ok(data),
@@ -132,7 +134,7 @@ impl HttpClient {
             disguise: Some(disguise),
         };
         match self
-            .request::<Message, MessageCreate>("messages", Some(message))
+            .request::<Message, MessageCreate>("POST", "messages", Some(message))
             .await?
         {
             HttpResponse::Success(data) => Ok(data),
@@ -158,6 +160,7 @@ impl HttpClient {
     ) -> Result<SessionCreated> {
         match self
             .request::<SessionCreated, SessionCreate>(
+                "POST",
                 "sessions",
                 Some(SessionCreate {
                     identifier,
@@ -177,6 +180,7 @@ impl HttpClient {
     pub async fn delete_session(&self, session_id: u64, password: String) -> Result<()> {
         match self
             .request::<(), PasswordDeleteCredentials>(
+                "DELETE",
                 &format!("sessions/{}", session_id),
                 Some(PasswordDeleteCredentials { password }),
             )
@@ -189,9 +193,167 @@ impl HttpClient {
 
     /// Get all sessions.
     pub async fn get_sessions(&self) -> Result<Vec<Session>> {
-        match self.request::<Vec<Session>, ()>("sessions", None).await? {
+        match self
+            .request::<Vec<Session>, ()>("GET", "sessions", None)
+            .await?
+        {
             HttpResponse::Success(sessions) => Ok(sessions),
             HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get sessions: {:?}", err)),
+        }
+    }
+
+    /// Create a user.
+    pub async fn create_user(
+        &self,
+        username: String,
+        email: String,
+        password: String,
+    ) -> Result<User> {
+        match self
+            .request::<User, UserCreate>(
+                "POST",
+                "users",
+                Some(UserCreate {
+                    username,
+                    email,
+                    password,
+                }),
+            )
+            .await?
+        {
+            HttpResponse::Success(user) => Ok(user),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not create user: {:?}", err)),
+        }
+    }
+
+    /// Delete the current user.
+    pub async fn delete_user(&self, password: String) -> Result<()> {
+        match self
+            .request::<(), PasswordDeleteCredentials>(
+                "DELETE",
+                "users",
+                Some(PasswordDeleteCredentials { password }),
+            )
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not delete user: {:?}", err)),
+        }
+    }
+
+    /// Get the current user.
+    pub async fn get_user(&self) -> Result<User> {
+        match self.request::<User, ()>("GET", "users/@me", None).await? {
+            HttpResponse::Success(user) => Ok(user),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get user: {:?}", err)),
+        }
+    }
+
+    /// Update the current user.
+    pub async fn update_user(&self, update: UpdateUser) -> Result<User> {
+        match self
+            .request::<User, UpdateUser>("PATCH", "users", Some(update))
+            .await?
+        {
+            HttpResponse::Success(user) => Ok(user),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not update user: {:?}", err)),
+        }
+    }
+
+    /// Update the current user's profile.
+    pub async fn update_user_profile(&self, update: UpdateUserProfile) -> Result<User> {
+        match self
+            .request::<User, UpdateUserProfile>("PATCH", "users/profile", Some(update))
+            .await?
+        {
+            HttpResponse::Success(user) => Ok(user),
+            HttpResponse::Error(err) => {
+                Err(anyhow::anyhow!("Could not update user profile: {:?}", err))
+            }
+        }
+    }
+
+    /// Get a user by their id.
+    pub async fn get_user_by_id(&self, user_id: u64) -> Result<User> {
+        match self
+            .request::<User, ()>("GET", &format!("users/{}", user_id), None)
+            .await?
+        {
+            HttpResponse::Success(user) => Ok(user),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get user: {:?}", err)),
+        }
+    }
+
+    /// Get a user by their username.
+    pub async fn get_user_by_username(&self, username: String) -> Result<User> {
+        match self
+            .request::<User, ()>("GET", &format!("users/{}", username), None)
+            .await?
+        {
+            HttpResponse::Success(user) => Ok(user),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get user: {:?}", err)),
+        }
+    }
+
+    /// Verify your email address.
+    pub async fn verify_user(&self, code: String) -> Result<()> {
+        match self
+            .request::<(), u8>("POST", &format!("/users/verify?{code}"), None)
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not verify user: {:?}", err)),
+        }
+    }
+
+    /// Resend the verification email.
+    pub async fn resend_verification(&self) -> Result<()> {
+        match self
+            .request::<(), u8>("POST", "/users/resend-verification", None)
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!(
+                "Could not resend verification email: {:?}",
+                err
+            )),
+        }
+    }
+
+    /// Create password reset code.
+    pub async fn create_password_reset(&self, email: String) -> Result<()> {
+        match self
+            .request::<(), serde_json::Value>(
+                "POST",
+                "/users/reset-password",
+                Some(json!({ "email": email })),
+            )
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!(
+                "Could not create password reset code: {:?}",
+                err
+            )),
+        }
+    }
+
+    /// Reset your password.
+    pub async fn reset_password(&self, code: u32, email: String, password: String) -> Result<()> {
+        match self
+            .request::<(), ResetPassword>(
+                "POST",
+                "/users/reset-password",
+                Some(ResetPassword {
+                    code,
+                    email,
+                    password,
+                }),
+            )
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not reset password: {:?}", err)),
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,14 +1,17 @@
-use crate::{models::HttpResponse, GatewayClient, REST_URL};
+use crate::{
+    builders::{
+        CreateChannel, CreateMessage, CreateSphere, EditCategory, EditChannel, EditEmoji,
+        EditMember, EditMessage, EditUser, EditUserProfile, GetMessages,
+    },
+    models::{HttpResponse, ProxyResponse, SphereIdentifier, UserIdentifier},
+    GatewayClient, REST_URL,
+};
 use anyhow::Result;
 use reqwest::{Client, Method};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Map};
-use std::{fmt::Display, str::FromStr, time::Duration};
-use todel::models::{
-    Category, ErrorResponse, InstanceInfo, Message, MessageCreate, MessageDisguise,
-    PasswordDeleteCredentials, PasswordReset, Session, SessionCreate, SessionCreated, Sphere,
-    SphereChannel, SphereType, User, UserCreate, UserEdit, UserProfileEdit,
-};
+use serde_json::json;
+use std::{str::FromStr, time::Duration};
+use todel::models::*;
 use tokio::time;
 
 /// Simple Http client
@@ -46,22 +49,11 @@ impl HttpClient {
         self
     }
 
-    /// Fetch the info payload of an instance
-    pub async fn fetch_instance_info(&self) -> Result<InstanceInfo> {
-        Ok(self.client.get(&self.rest_url).send().await?.json().await?)
-    }
-
-    /// Try to get the client's internal InstanceInfo or fetch it if it does not already exist
-    pub async fn get_instance_info(&mut self) -> Result<&InstanceInfo> {
-        if self.instance_info.is_some() {
-            Ok(self.instance_info.as_ref().unwrap())
-        } else {
-            self.instance_info = Some(self.fetch_instance_info().await?);
-            Ok(self.instance_info.as_ref().unwrap())
-        }
-    }
-
-    async fn request<T: for<'a> Deserialize<'a>, Q: Serialize + ?Sized, B: Serialize + Sized>(
+    pub(crate) async fn request<
+        T: for<'a> Deserialize<'a>,
+        Q: Serialize + ?Sized,
+        B: Serialize + Sized,
+    >(
         &self,
         method: &str,
         path: &str,
@@ -121,86 +113,142 @@ impl HttpClient {
         }
     }
 
-    /// Send a message
-    pub async fn send_message<C: Display>(
-        &self,
-        channel_id: u64,
-        content: C,
-        reference: Option<u64>,
-    ) -> Result<Message> {
-        self.send_msg(channel_id, content.to_string(), None, reference)
-            .await
-    }
+    // # Channels
 
-    /// Send a message with a [`MessageDisguise`]
-    pub async fn send_message_with_disguise<C: Display>(
-        &self,
-        channel_id: u64,
-        content: C,
-        disguise: MessageDisguise,
-        reference: Option<u64>,
-    ) -> Result<Message> {
-        self.send_msg(channel_id, content.to_string(), Some(disguise), reference)
-            .await
-    }
-
-    async fn send_msg(
-        &self,
-        channel_id: u64,
-        content: String,
-        disguise: Option<MessageDisguise>,
-        reference: Option<u64>,
-    ) -> Result<Message> {
-        let message = MessageCreate {
-            content,
-            disguise,
-            reference,
-        };
+    /// Get a channel by its ID.
+    pub async fn get_channel(&self, channel_id: u64) -> Result<SphereChannel> {
         match self
-            .request::<Message, (), MessageCreate>(
-                "POST",
-                &format!("/channels/{}/messages", channel_id),
-                None,
-                Some(message),
-            )
-            .await?
-        {
-            HttpResponse::Success(data) => Ok(data),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could) not send message: {:?}", err)),
-        }
-    }
-
-    /// Get messages from a channel.
-    pub async fn get_messages(
-        &self,
-        channel_id: u64,
-        before: Option<u64>,
-        after: Option<u64>,
-        limit: Option<u8>,
-    ) -> Result<Vec<Message>> {
-        let mut query = vec![];
-        if let Some(before) = before {
-            query.push(("before", before.to_string()));
-        }
-        if let Some(after) = after {
-            query.push(("after", after.to_string()));
-        }
-        if let Some(limit) = limit {
-            query.push(("limit", limit.to_string()));
-        }
-        match self
-            .request::<Vec<Message>, Vec<(&str, String)>, ()>(
+            .request::<SphereChannel, (), ()>(
                 "GET",
-                &format!("channels/{}/messages", channel_id),
-                Some(&query),
+                &format!("channels/{}", channel_id),
+                None,
                 None,
             )
             .await?
         {
-            HttpResponse::Success(messages) => Ok(messages),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get messages: {:?}", err)),
+            HttpResponse::Success(channel) => Ok(channel),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get channel: {:?}", err)),
         }
     }
+
+    // # Emojis
+
+    /// Add a reaction to a message.
+    pub async fn add_reaction(
+        &self,
+        channel_id: u64,
+        message_id: u64,
+        emoji: ReactionEmoji,
+    ) -> Result<Message> {
+        let emoji_ref = emoji.get_ref();
+        match self
+            .request::<Message, (), ReactionEmojiReference>(
+                "POST",
+                &format!("channels/{}/messages/{}/reactions", channel_id, message_id),
+                None,
+                Some(emoji_ref),
+            )
+            .await?
+        {
+            HttpResponse::Success(message) => Ok(message),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not add reaction: {:?}", err)),
+        }
+    }
+
+    /// Remove all reactions from a message.
+    pub async fn clear_reactions(&self, channel_id: u64, message_id: u64) -> Result<Message> {
+        match self
+            .request::<Message, (), ()>(
+                "DELETE",
+                &format!(
+                    "channels/{}/messages/{}/reactions/clear",
+                    channel_id, message_id
+                ),
+                None,
+                None,
+            )
+            .await?
+        {
+            HttpResponse::Success(message) => Ok(message),
+            HttpResponse::Error(err) => {
+                Err(anyhow::anyhow!("Could not clear reactions: {:?}", err))
+            }
+        }
+    }
+
+    /// Remove a reaction from a message.
+    pub async fn remove_reaction(
+        &self,
+        channel_id: u64,
+        message_id: u64,
+        emoji: ReactionEmoji,
+    ) -> Result<Message> {
+        let emoji_ref = emoji.get_ref();
+        match self
+            .request::<Message, (), ReactionEmojiReference>(
+                "DELETE",
+                &format!("channels/{}/messages/{}/reactions", channel_id, message_id),
+                None,
+                Some(emoji_ref),
+            )
+            .await?
+        {
+            HttpResponse::Success(message) => Ok(message),
+            HttpResponse::Error(err) => {
+                Err(anyhow::anyhow!("Could not remove reaction: {:?}", err))
+            }
+        }
+    }
+
+    /// Create an emoji within a sphere.
+    pub async fn create_emoji(
+        &self,
+        sphere_identifier: SphereIdentifier,
+        file_id: u64,
+        name: String,
+    ) -> Result<Emoji> {
+        match self
+            .request::<Emoji, (), EmojiCreate>(
+                "POST",
+                &format!("spheres/{}/emojis", sphere_identifier),
+                None,
+                Some(EmojiCreate { file_id, name }),
+            )
+            .await?
+        {
+            HttpResponse::Success(emoji) => Ok(emoji),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not create emoji: {:?}", err)),
+        }
+    }
+
+    /// Get an emoji by its ID.
+    pub async fn get_emoji(&self, emoji_id: u64) -> Result<Emoji> {
+        match self
+            .request::<Emoji, (), ()>("GET", &format!("emojis/{}", emoji_id), None, None)
+            .await?
+        {
+            HttpResponse::Success(emoji) => Ok(emoji),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get emoji: {:?}", err)),
+        }
+    }
+
+    /// Edit an emoji.
+    pub async fn edit_emoji(&self, emoji_id: u64) -> EditEmoji<'_> {
+        EditEmoji::new(self, emoji_id)
+    }
+
+    /// Delete an emoji.
+    pub async fn delete_emoji(&self, emoji_id: u64) -> Result<()> {
+        match self
+            .request::<(), (), ()>("DELETE", &format!("emojis/{}", emoji_id), None, None)
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not delete emoji: {:?}", err)),
+        }
+    }
+
+    // # Gateway
 
     /// Create a [`GatewayClient`] using the connected instance's instance info
     /// pandemonium url if any.
@@ -209,6 +257,122 @@ impl HttpClient {
         let gateway_url = info.pandemonium_url.clone();
         Ok(GatewayClient::new(&self.token).gateway_url(gateway_url))
     }
+
+    // # Instance
+
+    /// Fetch the info payload of an instance
+    pub async fn fetch_instance_info(&self) -> Result<InstanceInfo> {
+        Ok(self.client.get(&self.rest_url).send().await?.json().await?)
+    }
+
+    /// Try to get the client's internal InstanceInfo or fetch it if it does not already exist
+    pub async fn get_instance_info(&mut self) -> Result<&InstanceInfo> {
+        if self.instance_info.is_some() {
+            Ok(self.instance_info.as_ref().unwrap())
+        } else {
+            self.instance_info = Some(self.fetch_instance_info().await?);
+            Ok(self.instance_info.as_ref().unwrap())
+        }
+    }
+
+    // # Members
+
+    /// Get a member.
+    pub async fn get_member(
+        &self,
+        sphere_id: u64,
+        member_identifier: UserIdentifier,
+    ) -> Result<Member> {
+        match self
+            .request::<Member, (), ()>(
+                "GET",
+                &format!("spheres/{}/members/{}", sphere_id, member_identifier),
+                None,
+                None,
+            )
+            .await?
+        {
+            HttpResponse::Success(member) => Ok(member),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get member: {:?}", err)),
+        }
+    }
+
+    /// Edit a member.
+    pub async fn edit_member(
+        &self,
+        sphere_id: u64,
+        member_identifier: UserIdentifier,
+    ) -> EditMember<'_> {
+        EditMember::new(self, sphere_id, member_identifier)
+    }
+
+    // # Messaging
+
+    /// Send a message
+    pub async fn send_message(&self, channel_id: u64) -> CreateMessage {
+        CreateMessage::new(self, channel_id)
+    }
+
+    /// Edit a message.
+    pub async fn edit_message(&self, channel_id: u64, message_id: u64) -> EditMessage<'_> {
+        EditMessage::new(self, channel_id, message_id)
+    }
+
+    /// Delete a message.
+    pub async fn delete_message(&self, channel_id: u64, message_id: u64) -> Result<()> {
+        match self
+            .request::<(), (), ()>(
+                "DELETE",
+                &format!("channels/{}/messages/{}", channel_id, message_id),
+                None,
+                None,
+            )
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not delete message: {:?}", err)),
+        }
+    }
+
+    /// Get a message by its ID.
+    pub async fn get_message(&self, channel_id: u64, message_id: u64) -> Result<Message> {
+        match self
+            .request::<Message, (), ()>(
+                "GET",
+                &format!("channels/{}/messages/{}", channel_id, message_id),
+                None,
+                None,
+            )
+            .await?
+        {
+            HttpResponse::Success(message) => Ok(message),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get message: {:?}", err)),
+        }
+    }
+
+    /// Get messages from a channel.
+    pub async fn get_messages(&self, channel_id: u64) -> GetMessages<'_> {
+        GetMessages::new(self, channel_id)
+    }
+
+    // # Proxy
+
+    pub async fn proxy(&self, url: String) -> Result<ProxyResponse> {
+        match self
+            .request::<ProxyResponse, [(&str, String)], ()>(
+                "GET",
+                "format",
+                Some(&[("url", url)]),
+                None,
+            )
+            .await?
+        {
+            HttpResponse::Success(response) => Ok(response),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not proxy request: {:?}", err)),
+        }
+    }
+
+    // # Sessions
 
     /// Create a session.
     pub async fn create_session(
@@ -264,6 +428,114 @@ impl HttpClient {
         }
     }
 
+    // # Spheres
+
+    /// Create a category.
+    pub async fn create_category(&self, sphere_id: u64, name: String) -> Result<Category> {
+        match self
+            .request::<Category, (), CategoryCreate>(
+                "POST",
+                &format!("spheres/{}/categories", sphere_id),
+                None,
+                Some(CategoryCreate { name }),
+            )
+            .await?
+        {
+            HttpResponse::Success(category) => Ok(category),
+            HttpResponse::Error(err) => {
+                Err(anyhow::anyhow!("Could not create category: {:?}", err))
+            }
+        }
+    }
+
+    /// Edit a category.
+    pub async fn edit_category(&self, sphere_id: u64, category_id: u64) -> EditCategory<'_> {
+        EditCategory::new(self, sphere_id, category_id)
+    }
+
+    /// Delete a category.
+    pub async fn delete_category(&self, sphere_id: u64, category_id: u64) -> Result<()> {
+        match self
+            .request::<(), (), ()>(
+                "DELETE",
+                &format!("spheres/{}/categories/{}", sphere_id, category_id),
+                None,
+                None,
+            )
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => {
+                Err(anyhow::anyhow!("Could not delete category: {:?}", err))
+            }
+        }
+    }
+
+    /// Create a channel.
+    pub async fn create_channel(
+        &self,
+        sphere_id: u64,
+        name: String,
+        channel_type: SphereChannelType,
+    ) -> CreateChannel<'_> {
+        CreateChannel::new(self, sphere_id, name, channel_type)
+    }
+
+    /// Edit a channel.
+    pub async fn edit_channel(&self, sphere_id: u64, channel_id: u64) -> EditChannel<'_> {
+        EditChannel::new(self, sphere_id, channel_id)
+    }
+
+    /// Delete a channel.
+    pub async fn delete_channel(&self, sphere_id: u64, channel_id: u64) -> Result<()> {
+        match self
+            .request::<(), (), ()>(
+                "DELETE",
+                &format!("spheres/{}/channels/{}", sphere_id, channel_id),
+                None,
+                None,
+            )
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not delete channel: {:?}", err)),
+        }
+    }
+
+    /// Create a sphere.
+    pub async fn create_sphere(&self, slug: String, sphere_type: SphereType) -> CreateSphere<'_> {
+        CreateSphere::new(self, slug, sphere_type)
+    }
+
+    /// Get a sphere by its ID or slug.
+    pub async fn get_sphere(&self, sphere_identifier: SphereIdentifier) -> Result<Sphere> {
+        match self
+            .request::<Sphere, (), ()>("GET", &format!("spheres/{}", sphere_identifier), None, None)
+            .await?
+        {
+            HttpResponse::Success(sphere) => Ok(sphere),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get sphere: {:?}", err)),
+        }
+    }
+
+    /// Join a sphere by its ID or slug.
+    pub async fn join_sphere(&self, sphere_identifier: SphereIdentifier) -> Result<()> {
+        match self
+            .request::<(), (), ()>(
+                "GET",
+                &format!("spheres/{}/join", sphere_identifier),
+                None,
+                None,
+            )
+            .await?
+        {
+            HttpResponse::Success(_) => Ok(()),
+            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not join sphere: {:?}", err)),
+        }
+    }
+
+    // # Users
+
     /// Create a user.
     pub async fn create_user(
         &self,
@@ -306,7 +578,7 @@ impl HttpClient {
     }
 
     /// Get the current user.
-    pub async fn get_user(&self) -> Result<User> {
+    pub async fn get_current_user(&self) -> Result<User> {
         match self
             .request::<User, (), ()>("GET", "users/@me", None, None)
             .await?
@@ -316,45 +588,20 @@ impl HttpClient {
         }
     }
 
-    /// Update the current user.
-    pub async fn update_user(&self, update: UserEdit) -> Result<User> {
-        match self
-            .request::<User, (), UserEdit>("PATCH", "users", None, Some(update))
-            .await?
-        {
-            HttpResponse::Success(user) => Ok(user),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not update user: {:?}", err)),
-        }
+    /// Edit the current user.
+    pub async fn edit_user(&self, password: String) -> EditUser<'_> {
+        EditUser::new(self, password)
     }
 
-    /// Update the current user's profile.
-    pub async fn update_user_profile(&self, update: UserProfileEdit) -> Result<User> {
-        match self
-            .request::<User, (), UserProfileEdit>("PATCH", "users/profile", None, Some(update))
-            .await?
-        {
-            HttpResponse::Success(user) => Ok(user),
-            HttpResponse::Error(err) => {
-                Err(anyhow::anyhow!("Could not update user profile: {:?}", err))
-            }
-        }
+    /// Edit the current user's profile.
+    pub async fn edit_user_profile(&self) -> EditUserProfile<'_> {
+        EditUserProfile::new(self)
     }
 
-    /// Get a user by their id.
-    pub async fn get_user_by_id(&self, user_id: u64) -> Result<User> {
+    /// Get a user by their ID or username.
+    pub async fn get_user(&self, user_identifier: UserIdentifier) -> Result<User> {
         match self
-            .request::<User, (), ()>("GET", &format!("users/{}", user_id), None, None)
-            .await?
-        {
-            HttpResponse::Success(user) => Ok(user),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get user: {:?}", err)),
-        }
-    }
-
-    /// Get a user by their username.
-    pub async fn get_user_by_username(&self, username: String) -> Result<User> {
-        match self
-            .request::<User, (), ()>("GET", &format!("users/{}", username), None, None)
+            .request::<User, (), ()>("GET", &format!("users/{}", user_identifier), None, None)
             .await?
         {
             HttpResponse::Success(user) => Ok(user),
@@ -367,7 +614,7 @@ impl HttpClient {
         match self
             .request::<(), [(&str, String)], ()>(
                 "POST",
-                "/users/verify",
+                "users/verify",
                 Some(&[("code", code)]),
                 None,
             )
@@ -381,7 +628,7 @@ impl HttpClient {
     /// Resend the verification email.
     pub async fn resend_verification(&self) -> Result<()> {
         match self
-            .request::<(), (), u8>("POST", "/users/resend-verification", None, None)
+            .request::<(), (), u8>("POST", "users/resend-verification", None, None)
             .await?
         {
             HttpResponse::Success(_) => Ok(()),
@@ -397,7 +644,7 @@ impl HttpClient {
         match self
             .request::<(), (), serde_json::Value>(
                 "POST",
-                "/users/reset-password",
+                "users/reset-password",
                 None,
                 Some(json!({ "email": email })),
             )
@@ -416,7 +663,7 @@ impl HttpClient {
         match self
             .request::<(), (), PasswordReset>(
                 "POST",
-                "/users/reset-password",
+                "users/reset-password",
                 None,
                 Some(PasswordReset {
                     code,
@@ -428,254 +675,6 @@ impl HttpClient {
         {
             HttpResponse::Success(_) => Ok(()),
             HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not reset password: {:?}", err)),
-        }
-    }
-
-    /// Get a channel by its id.
-    pub async fn get_channel(&self, channel_id: u64) -> Result<SphereChannel> {
-        match self
-            .request::<SphereChannel, (), ()>(
-                "GET",
-                &format!("channels/{}", channel_id),
-                None,
-                None,
-            )
-            .await?
-        {
-            HttpResponse::Success(channel) => Ok(channel),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get channel: {:?}", err)),
-        }
-    }
-
-    /// Create a category.
-    pub async fn create_category(&self, sphere_id: u64, name: String) -> Result<Category> {
-        match self
-            .request::<Category, (), serde_json::Value>(
-                "POST",
-                &format!("spheres/{}/categories", sphere_id),
-                None,
-                Some(json!({ "name": name })),
-            )
-            .await?
-        {
-            HttpResponse::Success(category) => Ok(category),
-            HttpResponse::Error(err) => {
-                Err(anyhow::anyhow!("Could not create category: {:?}", err))
-            }
-        }
-    }
-
-    /// Edit a category.
-    pub async fn edit_category(
-        &self,
-        sphere_id: u64,
-        category_id: u64,
-        name: Option<String>,
-        position: Option<u8>,
-    ) -> Result<Category> {
-        let mut map = Map::new();
-        if let Some(name) = name {
-            map.insert("name".to_string(), name.into());
-        };
-        if let Some(position) = position {
-            map.insert("position".to_string(), position.into());
-        };
-
-        match self
-            .request::<Category, (), serde_json::Value>(
-                "PATCH",
-                &format!("spheres/{}/categories/{}", sphere_id, category_id),
-                None,
-                Some(serde_json::Value::Object(map)),
-            )
-            .await?
-        {
-            HttpResponse::Success(category) => Ok(category),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not edit category: {:?}", err)),
-        }
-    }
-
-    /// Delete a category.
-    pub async fn delete_category(&self, sphere_id: u64, category_id: u64) -> Result<()> {
-        match self
-            .request::<(), (), ()>(
-                "DELETE",
-                &format!("spheres/{}/categories/{}", sphere_id, category_id),
-                None,
-                None,
-            )
-            .await?
-        {
-            HttpResponse::Success(_) => Ok(()),
-            HttpResponse::Error(err) => {
-                Err(anyhow::anyhow!("Could not delete category: {:?}", err))
-            }
-        }
-    }
-
-    /// Create a text channel.
-    pub async fn create_text_channel(
-        &self,
-        sphere_id: u64,
-        name: String,
-        topic: Option<String>,
-        category_id: Option<u64>,
-    ) -> Result<SphereChannel> {
-        let mut map = Map::new();
-        map.insert("name".to_string(), name.into());
-        map.insert("type".to_string(), "text".into());
-        if let Some(topic) = topic {
-            map.insert("topic".to_string(), topic.into());
-        };
-        if let Some(category_id) = category_id {
-            map.insert("category_id".to_string(), category_id.into());
-        };
-
-        match self
-            .request::<SphereChannel, (), serde_json::Value>(
-                "POST",
-                &format!("spheres/{}/channels", sphere_id),
-                None,
-                Some(serde_json::Value::Object(map)),
-            )
-            .await?
-        {
-            HttpResponse::Success(channel) => Ok(channel),
-            HttpResponse::Error(err) => {
-                Err(anyhow::anyhow!("Could not create text channel: {:?}", err))
-            }
-        }
-    }
-
-    /// Edit a text channel.
-    pub async fn edit_text_channel(
-        &self,
-        sphere_id: u64,
-        channel_id: u64,
-        name: Option<String>,
-        topic: Option<String>,
-        position: Option<u8>,
-    ) -> Result<SphereChannel> {
-        let mut map = Map::new();
-        if let Some(name) = name {
-            map.insert("name".to_string(), name.into());
-        };
-        if let Some(topic) = topic {
-            map.insert("topic".to_string(), topic.into());
-        };
-        if let Some(position) = position {
-            map.insert("position".to_string(), position.into());
-        };
-
-        match self
-            .request::<SphereChannel, (), serde_json::Value>(
-                "PATCH",
-                &format!("spheres/{}/channels/{}", sphere_id, channel_id),
-                None,
-                Some(serde_json::Value::Object(map)),
-            )
-            .await?
-        {
-            HttpResponse::Success(channel) => Ok(channel),
-            HttpResponse::Error(err) => {
-                Err(anyhow::anyhow!("Could not edit text channel: {:?}", err))
-            }
-        }
-    }
-
-    /// Delete a channel.
-    pub async fn delete_channel(&self, sphere_id: u64, channel_id: u64) -> Result<()> {
-        match self
-            .request::<(), (), ()>(
-                "DELETE",
-                &format!("spheres/{}/channels/{}", sphere_id, channel_id),
-                None,
-                None,
-            )
-            .await?
-        {
-            HttpResponse::Success(_) => Ok(()),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not delete channel: {:?}", err)),
-        }
-    }
-
-    /// Create a sphere.
-    pub async fn create_sphere(
-        &self,
-        slug: String,
-        typ: SphereType,
-        description: Option<String>,
-        icon: Option<u64>,
-        banner: Option<u64>,
-    ) -> Result<Sphere> {
-        let mut map = Map::new();
-        map.insert("slug".to_string(), slug.into());
-        map.insert("type".to_string(), serde_json::to_value(typ)?);
-        if let Some(description) = description {
-            map.insert("description".to_string(), description.into());
-        };
-        if let Some(icon) = icon {
-            map.insert("icon".to_string(), icon.into());
-        };
-        if let Some(banner) = banner {
-            map.insert("banner".to_string(), banner.into());
-        };
-
-        match self
-            .request::<Sphere, (), serde_json::Value>(
-                "POST",
-                "spheres",
-                None,
-                Some(serde_json::Value::Object(map)),
-            )
-            .await?
-        {
-            HttpResponse::Success(sphere) => Ok(sphere),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not create sphere: {:?}", err)),
-        }
-    }
-
-    /// Get a sphere by its id.
-    pub async fn get_sphere(&self, sphere_id: u64) -> Result<Sphere> {
-        match self
-            .request::<Sphere, (), ()>("GET", &format!("spheres/{}", sphere_id), None, None)
-            .await?
-        {
-            HttpResponse::Success(sphere) => Ok(sphere),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get sphere: {:?}", err)),
-        }
-    }
-
-    /// Get a sphere by its slug.
-    pub async fn get_sphere_by_slug(&self, slug: String) -> Result<Sphere> {
-        match self
-            .request::<Sphere, (), ()>("GET", &format!("spheres/{}", slug), None, None)
-            .await?
-        {
-            HttpResponse::Success(sphere) => Ok(sphere),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get sphere: {:?}", err)),
-        }
-    }
-
-    /// Join a sphere by its id.
-    pub async fn join_sphere(&self, sphere_id: u64) -> Result<()> {
-        match self
-            .request::<(), (), ()>("GET", &format!("spheres/{}/join", sphere_id), None, None)
-            .await?
-        {
-            HttpResponse::Success(_) => Ok(()),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not join sphere: {:?}", err)),
-        }
-    }
-
-    /// Join a sphere by its slug.
-    pub async fn join_sphere_by_slug(&self, slug: String) -> Result<()> {
-        match self
-            .request::<(), (), ()>("GET", &format!("spheres/{}/join", slug), None, None)
-            .await?
-        {
-            HttpResponse::Success(_) => Ok(()),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not join sphere: {:?}", err)),
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -7,7 +7,7 @@ use std::{fmt::Display, str::FromStr, time::Duration};
 use todel::models::{
     Category, ErrorResponse, InstanceInfo, Message, MessageCreate, MessageDisguise,
     PasswordDeleteCredentials, PasswordReset, Session, SessionCreate, SessionCreated, Sphere,
-    SphereChannel, SphereType, UpdateUser, UpdateUserProfile, User, UserCreate,
+    SphereChannel, SphereType, User, UserCreate, UserEdit, UserProfileEdit,
 };
 use tokio::time;
 
@@ -317,9 +317,9 @@ impl HttpClient {
     }
 
     /// Update the current user.
-    pub async fn update_user(&self, update: UpdateUser) -> Result<User> {
+    pub async fn update_user(&self, update: UserEdit) -> Result<User> {
         match self
-            .request::<User, (), UpdateUser>("PATCH", "users", None, Some(update))
+            .request::<User, (), UserEdit>("PATCH", "users", None, Some(update))
             .await?
         {
             HttpResponse::Success(user) => Ok(user),
@@ -328,9 +328,9 @@ impl HttpClient {
     }
 
     /// Update the current user's profile.
-    pub async fn update_user_profile(&self, update: UpdateUserProfile) -> Result<User> {
+    pub async fn update_user_profile(&self, update: UserProfileEdit) -> Result<User> {
         match self
-            .request::<User, (), UpdateUserProfile>("PATCH", "users/profile", None, Some(update))
+            .request::<User, (), UserProfileEdit>("PATCH", "users/profile", None, Some(update))
             .await?
         {
             HttpResponse::Success(user) => Ok(user),

--- a/src/http.rs
+++ b/src/http.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Map};
 use std::{fmt::Display, str::FromStr, time::Duration};
 use todel::models::{
     Category, ErrorResponse, InstanceInfo, Message, MessageCreate, MessageDisguise,
-    PasswordDeleteCredentials, ResetPassword, Session, SessionCreate, SessionCreated, Sphere,
+    PasswordDeleteCredentials, PasswordReset, Session, SessionCreate, SessionCreated, Sphere,
     SphereChannel, SphereType, UpdateUser, UpdateUserProfile, User, UserCreate,
 };
 use tokio::time;
@@ -414,11 +414,11 @@ impl HttpClient {
     /// Reset your password.
     pub async fn reset_password(&self, code: u32, email: String, password: String) -> Result<()> {
         match self
-            .request::<(), (), ResetPassword>(
+            .request::<(), (), PasswordReset>(
                 "POST",
                 "/users/reset-password",
                 None,
-                Some(ResetPassword {
+                Some(PasswordReset {
                     code,
                     email,
                     password,

--- a/src/http.rs
+++ b/src/http.rs
@@ -577,17 +577,6 @@ impl HttpClient {
         }
     }
 
-    /// Get the current user.
-    pub async fn get_current_user(&self) -> Result<User> {
-        match self
-            .request::<User, (), ()>("GET", "users/@me", None, None)
-            .await?
-        {
-            HttpResponse::Success(user) => Ok(user),
-            HttpResponse::Error(err) => Err(anyhow::anyhow!("Could not get user: {:?}", err)),
-        }
-    }
-
     /// Edit the current user.
     pub async fn edit_user(&self, password: String) -> EditUser<'_> {
         EditUser::new(self, password)
@@ -598,7 +587,7 @@ impl HttpClient {
         EditUserProfile::new(self)
     }
 
-    /// Get a user by their ID or username.
+    /// Get a user by their ID, username, or @me for the current user.
     pub async fn get_user(&self, user_identifier: UserIdentifier) -> Result<User> {
         match self
             .request::<User, (), ()>("GET", &format!("users/{}", user_identifier), None, None)

--- a/src/http.rs
+++ b/src/http.rs
@@ -233,7 +233,7 @@ impl HttpClient {
     }
 
     /// Edit an emoji.
-    pub async fn edit_emoji(&self, emoji_id: u64) -> EditEmoji<'_> {
+    pub fn edit_emoji(&self, emoji_id: u64) -> EditEmoji<'_> {
         EditEmoji::new(self, emoji_id)
     }
 
@@ -298,23 +298,19 @@ impl HttpClient {
     }
 
     /// Edit a member.
-    pub async fn edit_member(
-        &self,
-        sphere_id: u64,
-        member_identifier: UserIdentifier,
-    ) -> EditMember<'_> {
+    pub fn edit_member(&self, sphere_id: u64, member_identifier: UserIdentifier) -> EditMember<'_> {
         EditMember::new(self, sphere_id, member_identifier)
     }
 
     // # Messaging
 
     /// Send a message
-    pub async fn send_message(&self, channel_id: u64) -> CreateMessage {
+    pub fn send_message(&self, channel_id: u64) -> CreateMessage {
         CreateMessage::new(self, channel_id)
     }
 
     /// Edit a message.
-    pub async fn edit_message(&self, channel_id: u64, message_id: u64) -> EditMessage<'_> {
+    pub fn edit_message(&self, channel_id: u64, message_id: u64) -> EditMessage<'_> {
         EditMessage::new(self, channel_id, message_id)
     }
 
@@ -351,7 +347,7 @@ impl HttpClient {
     }
 
     /// Get messages from a channel.
-    pub async fn get_messages(&self, channel_id: u64) -> GetMessages<'_> {
+    pub fn get_messages(&self, channel_id: u64) -> GetMessages<'_> {
         GetMessages::new(self, channel_id)
     }
 
@@ -449,7 +445,7 @@ impl HttpClient {
     }
 
     /// Edit a category.
-    pub async fn edit_category(&self, sphere_id: u64, category_id: u64) -> EditCategory<'_> {
+    pub fn edit_category(&self, sphere_id: u64, category_id: u64) -> EditCategory<'_> {
         EditCategory::new(self, sphere_id, category_id)
     }
 
@@ -472,7 +468,7 @@ impl HttpClient {
     }
 
     /// Create a channel.
-    pub async fn create_channel(
+    pub fn create_channel(
         &self,
         sphere_id: u64,
         name: String,
@@ -482,7 +478,7 @@ impl HttpClient {
     }
 
     /// Edit a channel.
-    pub async fn edit_channel(&self, sphere_id: u64, channel_id: u64) -> EditChannel<'_> {
+    pub fn edit_channel(&self, sphere_id: u64, channel_id: u64) -> EditChannel<'_> {
         EditChannel::new(self, sphere_id, channel_id)
     }
 
@@ -503,7 +499,7 @@ impl HttpClient {
     }
 
     /// Create a sphere.
-    pub async fn create_sphere(&self, slug: String, sphere_type: SphereType) -> CreateSphere<'_> {
+    pub fn create_sphere(&self, slug: String, sphere_type: SphereType) -> CreateSphere<'_> {
         CreateSphere::new(self, slug, sphere_type)
     }
 
@@ -578,12 +574,12 @@ impl HttpClient {
     }
 
     /// Edit the current user.
-    pub async fn edit_user(&self, password: String) -> EditUser<'_> {
+    pub fn edit_user(&self, password: String) -> EditUser<'_> {
         EditUser::new(self, password)
     }
 
     /// Edit the current user's profile.
-    pub async fn edit_user_profile(&self) -> EditUserProfile<'_> {
+    pub fn edit_user_profile(&self) -> EditUserProfile<'_> {
         EditUserProfile::new(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub use http::HttpClient;
 
 /// All the todel models re-exported
 pub mod todel {
-    pub use todel::*;
+    pub use todel::models::*;
 }
 
 /// The default rest url

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub mod todel {
 }
 
 /// The default rest url
-pub const REST_URL: &str = "https://eludris.tooty.xyz";
+pub const REST_URL: &str = "https://api.eludris.com";
 
 /// The default gateway url
-pub const GATEWAY_URL: &str = "wss://eludris.tooty.xyz/ws/";
+pub const GATEWAY_URL: &str = "wss://ws.eludris.com/";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,6 @@ pub mod models;
 pub use gateway::{Events, GatewayClient};
 pub use http::HttpClient;
 
-/// All the todel models re-exported
-pub mod todel {
-    pub use todel::models::*;
-}
-
 /// The default rest url
 pub const REST_URL: &str = "https://api.eludris.com";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 //! ```shell
 //! cargo doc -p eludrs --open
 //! ```
+mod builders;
 mod gateway;
 mod http;
 pub mod models;

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,8 +3,8 @@ use todel::{ErrorResponse, Message, Status, User};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-pub(crate) enum MessageResponse {
-    Message(Message),
+pub(crate) enum HttpResponse<T> {
+    Success(T),
     Error(ErrorResponse),
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use todel::{ErrorResponse, Message, Status, User};
+use todel::models::{
+    Category, CategoryEdit, ErrorResponse, Message, Sphere, SphereChannel, SphereChannelEdit,
+    Status, User,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -15,12 +18,35 @@ pub enum Event {
     Authenticated,
     /// A message that has just been sent over the gateway
     Message(Message),
-    /// The old and new data after a user has been updated
-    UserUpdate { old_user: Option<User>, user: User },
-    /// The old and new data after a user's status has been updated
-    PresenceUpdate {
-        old_status: Option<Status>,
-        user_id: u64,
-        status: Status,
+    /// A users data has been updated
+    UserUpdate(User),
+    /// A user's status has been updated
+    PresenceUpdate { user_id: u64, status: Status },
+    /// This user has joined a sphere
+    SphereJoin(Sphere),
+    /// A user has joined a sphere
+    SphereMemberJoin { user: User, sphere_id: u64 },
+    /// A category has been created
+    CategoryCreate { category: Category, sphere_id: u64 },
+    /// A category has been edited
+    CategoryEdit {
+        data: CategoryEdit,
+        category_id: u64,
+        sphere_id: u64,
     },
+    /// A category has been deleted
+    CategoryDelete { category_id: u64, sphere_id: u64 },
+    /// A channel has been created
+    SphereChannelCreate {
+        channel: SphereChannel,
+        sphere_id: u64,
+    },
+    /// A channel has been edited
+    SphereChannelEdit {
+        data: SphereChannelEdit,
+        channel_id: u64,
+        sphere_id: u64,
+    },
+    /// A channel has been deleted
+    SphereChannelDelete { channel_id: u64, sphere_id: u64 },
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -51,7 +51,7 @@ pub enum Event {
     SphereChannelDelete { channel_id: u64, sphere_id: u64 },
 }
 
-/// Copy of [`todel::models::Sphere`], but without the members field.
+/// Copy of [`todel::models::Sphere`], but with a custom member model.
 /// This flattens the cache to be more efficient to update.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CachedSphere {

--- a/src/models.rs
+++ b/src/models.rs
@@ -29,7 +29,7 @@ pub enum Event {
     /// A category has been created
     CategoryCreate { category: Category, sphere_id: u64 },
     /// A category has been edited
-    CategoryEdit {
+    CategoryUpdate {
         data: CategoryEdit,
         category_id: u64,
         sphere_id: u64,
@@ -42,7 +42,7 @@ pub enum Event {
         sphere_id: u64,
     },
     /// A channel has been edited
-    SphereChannelEdit {
+    SphereChannelUpdate {
         data: SphereChannelEdit,
         channel_id: u64,
         sphere_id: u64,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,8 +1,7 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
-use todel::models::{
-    Category, CategoryEdit, Emoji, ErrorResponse, Member, Message, Sphere, SphereChannel,
-    SphereChannelEdit, SphereType, Status, User,
-};
+use todel::models::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -18,14 +17,45 @@ pub enum Event {
     Authenticated,
     /// A message that has just been sent over the gateway
     Message(Message),
+    /// A message that has been edit
+    MessageUpdate {
+        channel_id: u64,
+        message_id: u64,
+        data: MessageEdit,
+    },
+    /// A message that has been deleted
+    MessageDelete { channel_id: u64, message_id: u64 },
+    /// The embeds in a message have been populated
+    MessageEmbedPopulate {
+        channel_id: u64,
+        message_id: u64,
+        embeds: Vec<Embed>,
+    },
     /// A users data has been updated
     UserUpdate(User),
     /// A user's status has been updated
     PresenceUpdate { user_id: u64, status: Status },
     /// This user has joined a sphere
     SphereJoin(CachedSphere),
+    /// A sphere has been updated
+    SphereUpdate {
+        old: CachedSphere,
+        data: SphereEdit,
+        sphere_id: u64,
+    },
+    /// This user has left a sphere
+    SphereLeave(CachedSphere),
     /// A user has joined a sphere
-    SphereMemberJoin { user: User, sphere_id: u64 },
+    SphereMemberJoin(CachedMember),
+    /// A member updated their data in a sphere
+    MemberUpdate {
+        old: Member,
+        data: MemberEdit,
+        user_id: u64,
+        sphere_id: u64,
+    },
+    /// A user has left a sphere
+    SphereMemberLeave(CachedMember),
     /// A category has been created
     CategoryCreate { category: Category, sphere_id: u64 },
     /// A category has been edited
@@ -49,65 +79,82 @@ pub enum Event {
     },
     /// A channel has been deleted
     SphereChannelDelete { channel_id: u64, sphere_id: u64 },
+    /// An emoji has been created
+    EmojiCreate(Emoji),
+    /// An emoji has been edited
+    EmojiUpdate {
+        old: Emoji,
+        data: EmojiEdit,
+        emoji_id: u64,
+        sphere_id: u64,
+    },
+    /// An emoji has been deleted
+    EmojiDelete(Emoji),
+    /// A reaction has been added to a message
+    MessageReact {
+        channel_id: u64,
+        message_id: u64,
+        user_id: u64,
+        emoji: ReactionEmoji,
+    },
+    /// A reaction has been removed from a message
+    MessageReactionDelete {
+        channel_id: u64,
+        message_id: u64,
+        user_id: u64,
+        emoji: ReactionEmoji,
+    },
+    /// All reactions have been removed from a message
+    MessageReactionClear { channel_id: u64, message_id: u64 },
 }
 
-/// Copy of [`todel::models::Sphere`], but with a custom member model.
+/// Copy of [`todel::models::Sphere`], but with a custom member and emoji models stored in maps.
 /// This flattens the cache to be more efficient to update.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CachedSphere {
     /// The spheres's ID.
     pub id: u64,
     /// The ID of the sphere's owner.
     pub owner_id: u64,
     /// The name of the sphere.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// The slug of the sphere.
     pub slug: String,
     /// The sphere's type.
-    #[serde(rename = "type")]
     pub sphere_type: SphereType,
     /// The sphere's description, can be between 1 and 4096 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// The sphere's icon. This field has to be a valid file ID in the "sphere-icons" bucket.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub icon: Option<u64>,
     /// The sphere's banner. This field has to be a valid file ID in the "sphere-banners" bucket.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub banner: Option<u64>,
     /// The sphere's badges as a bitfield.
     pub badges: u64,
     /// The categories that this sphere contains.
     pub categories: Vec<Category>,
-    /// The members that are inside this sphere.
-    pub members: Vec<CachedMember>,
-    /// The emojis that this sphere has.
-    pub emojis: Vec<Emoji>,
+    /// The members that are inside this sphere, as a map.
+    pub members: HashMap<u64, CachedMember>,
+    /// The emojis that this sphere has, as a map.
+    pub emojis: HashMap<u64, Emoji>,
 }
 
 /// Copy of [`todel::models::Sphere`], but without the user field.
 /// This flattens the cache to be more efficient to update.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CachedMember {
     /// The underlying User's ID for this member.
     pub user_id: u64,
     /// The sphere to which this member belongs.
     pub sphere_id: u64,
     /// The sphere-specific nickname of this member.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub nickname: Option<String>,
     /// The sphere-specific avatar of this member.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sphere_avatar: Option<u64>,
     /// The sphere-specific banner of this member.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sphere_banner: Option<u64>,
     /// The sphere-specific bio of this member.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sphere_bio: Option<String>,
     /// The sphere-specific status of this member.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sphere_status: Option<String>,
 }
 
@@ -124,8 +171,12 @@ impl From<Sphere> for CachedSphere {
             banner: sphere.banner,
             badges: sphere.badges,
             categories: sphere.categories,
-            members: sphere.members.into_iter().map(|m| m.into()).collect(),
-            emojis: sphere.emojis,
+            members: sphere
+                .members
+                .into_iter()
+                .map(|m| (m.user.id, m.into()))
+                .collect(),
+            emojis: sphere.emojis.into_iter().map(|e| (e.id, e)).collect(),
         }
     }
 }
@@ -140,6 +191,21 @@ impl From<Member> for CachedMember {
             sphere_banner: member.sphere_banner,
             sphere_bio: member.sphere_bio,
             sphere_status: member.sphere_status,
+        }
+    }
+}
+
+impl CachedMember {
+    /// Converts a `CachedMember` back into a `Member` with the given user.
+    pub fn into_member(self, user: User) -> Member {
+        Member {
+            user,
+            sphere_id: self.sphere_id,
+            nickname: self.nickname,
+            sphere_avatar: self.sphere_avatar,
+            sphere_banner: self.sphere_banner,
+            sphere_bio: self.sphere_bio,
+            sphere_status: self.sphere_status,
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 use serde::{Deserialize, Serialize};
 use todel::models::*;
@@ -8,6 +8,44 @@ use todel::models::*;
 pub(crate) enum HttpResponse<T> {
     Success(T),
     Error(ErrorResponse),
+}
+
+#[derive(Clone, Debug)]
+pub enum SphereIdentifier {
+    ID(u64),
+    Slug(String),
+}
+
+impl Display for SphereIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SphereIdentifier::ID(id) => write!(f, "{}", id),
+            SphereIdentifier::Slug(slug) => f.write_str(slug),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum UserIdentifier {
+    Me,
+    ID(u64),
+    Username(String),
+}
+
+impl Display for UserIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UserIdentifier::Me => f.write_str("@me"),
+            UserIdentifier::ID(id) => write!(f, "{}", id),
+            UserIdentifier::Username(slug) => f.write_str(slug),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProxyResponse {
+    pub file: Vec<u8>,
+    pub content_type: String,
 }
 
 /// An abstraction over gateway event types

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use todel::models::{
-    Category, CategoryEdit, ErrorResponse, Message, Sphere, SphereChannel, SphereChannelEdit,
-    Status, User,
+    Category, CategoryEdit, Emoji, ErrorResponse, Member, Message, Sphere, SphereChannel,
+    SphereChannelEdit, SphereType, Status, User,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,7 +23,7 @@ pub enum Event {
     /// A user's status has been updated
     PresenceUpdate { user_id: u64, status: Status },
     /// This user has joined a sphere
-    SphereJoin(Sphere),
+    SphereJoin(CachedSphere),
     /// A user has joined a sphere
     SphereMemberJoin { user: User, sphere_id: u64 },
     /// A category has been created
@@ -49,4 +49,97 @@ pub enum Event {
     },
     /// A channel has been deleted
     SphereChannelDelete { channel_id: u64, sphere_id: u64 },
+}
+
+/// Copy of [`todel::models::Sphere`], but without the members field.
+/// This flattens the cache to be more efficient to update.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CachedSphere {
+    /// The spheres's ID.
+    pub id: u64,
+    /// The ID of the sphere's owner.
+    pub owner_id: u64,
+    /// The name of the sphere.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The slug of the sphere.
+    pub slug: String,
+    /// The sphere's type.
+    #[serde(rename = "type")]
+    pub sphere_type: SphereType,
+    /// The sphere's description, can be between 1 and 4096 characters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The sphere's icon. This field has to be a valid file ID in the "sphere-icons" bucket.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<u64>,
+    /// The sphere's banner. This field has to be a valid file ID in the "sphere-banners" bucket.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub banner: Option<u64>,
+    /// The sphere's badges as a bitfield.
+    pub badges: u64,
+    /// The categories that this sphere contains.
+    pub categories: Vec<Category>,
+    /// The members that are inside this sphere.
+    pub members: Vec<CachedMember>,
+    /// The emojis that this sphere has.
+    pub emojis: Vec<Emoji>,
+}
+
+/// Copy of [`todel::models::Sphere`], but without the user field.
+/// This flattens the cache to be more efficient to update.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CachedMember {
+    /// The underlying User's ID for this member.
+    pub user_id: u64,
+    /// The sphere to which this member belongs.
+    pub sphere_id: u64,
+    /// The sphere-specific nickname of this member.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nickname: Option<String>,
+    /// The sphere-specific avatar of this member.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sphere_avatar: Option<u64>,
+    /// The sphere-specific banner of this member.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sphere_banner: Option<u64>,
+    /// The sphere-specific bio of this member.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sphere_bio: Option<String>,
+    /// The sphere-specific status of this member.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sphere_status: Option<String>,
+}
+
+impl From<Sphere> for CachedSphere {
+    fn from(sphere: Sphere) -> Self {
+        Self {
+            id: sphere.id,
+            owner_id: sphere.owner_id,
+            name: sphere.name,
+            slug: sphere.slug,
+            sphere_type: sphere.sphere_type,
+            description: sphere.description,
+            icon: sphere.icon,
+            banner: sphere.banner,
+            badges: sphere.badges,
+            categories: sphere.categories,
+            members: sphere.members.into_iter().map(|m| m.into()).collect(),
+            emojis: sphere.emojis,
+        }
+    }
+}
+
+impl From<Member> for CachedMember {
+    fn from(member: Member) -> Self {
+        Self {
+            user_id: member.user.id,
+            sphere_id: member.sphere_id,
+            nickname: member.nickname,
+            sphere_avatar: member.sphere_avatar,
+            sphere_banner: member.sphere_banner,
+            sphere_bio: member.sphere_bio,
+            sphere_status: member.sphere_status,
+        }
+    }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt::Display};
 
 use serde::{Deserialize, Serialize};
-use todel::models::*;
+pub use todel::models::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]


### PR DESCRIPTION
This PR updates eludrs to support 0.4.0-alpha2 (users, spheres, emojis, channels, members, attachments, embeds).

This overwrites the previous 3 main commits as this was developed before then. This PR needs a good bit of testing.

This involves the following:
- Add caching within the gateway (not usable yet)
- Change the HTTP and gateway urls to eludris.com
- Allow passing a token to the HTTP and gateway clients
- Remove the default for the http and gateway clients as that is not relevant anymore
- Authenticate with the token in the gateway and http clients
- Add all possible events, dispatching them using the `Event` model over just `Message`s
- Create `HttpClient.request` for repeated use of request logic
- Export todel models under `models` not `todel`
- Create an abstract `HttpResponse` containing a type or error